### PR TITLE
build in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.dockerignore
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+FROM debian:10
+WORKDIR /root/wine
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    pkg-config \
+    flex \
+    bison \
+    fontforge \
+    librsvg2-bin \
+    imagemagick \
+    icoutils \
+    gettext \
+    libgnutls28-dev \
+    libgettextpo-dev \
+    libxml-libxml-perl \
+    libssl-dev \
+    libusb-1.0.0-dev \
+    gcc-mingw-w64-x86-64 \
+    g++-mingw-w64-x86-64
+COPY . .
+RUN ./configure \
+    --with-gnutls  \
+    --without-hal \
+    --without-oss  \
+    --without-x \
+    --without-freetype \
+    --disable-tests  \
+    --enable-win64 \
+    --enable-maintainer-mode \
+    CFLAGS='-g -O2 -fdebug-prefix-map=/root/wine=. -fstack-protector-strong -Wformat -Werror=format-security -Wno-error' \
+    CPPFLAGS='-Wdate-time -D_FORTIFY_SOURCE=2'  \
+    CXXFLAGS='-g -O2 -fdebug-prefix-map=/root/wine=. -fstack-protector-strong -Wformat -Werror=format-security' \
+    FCFLAGS='-g -O2 -fdebug-prefix-map=/root/wine=. -fstack-protector-strong'  \
+    FFLAGS='-g -O2 -fdebug-prefix-map=/root/wine=. -fstack-protector-strong'  \
+    GCJFLAGS='-g -O2 -fdebug-prefix-map=/root/wine=. -fstack-protector-strong'  \
+    LDFLAGS='-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now -Wl,-rpath,/usr/lib/x86_64-linux-gnu/wine'  \
+    OBJCFLAGS='-g -O2 -fdebug-prefix-map=/root/wine=. -fstack-protector-strong -Wformat -Werror=format-security'  \
+    OBJCXXFLAGS='-g -O2 -fdebug-prefix-map=/root/wine=. -fstack-protector-strong -Wformat -Werror=format-security'
+
+RUN make -j`nproc`
+RUN make DESTDIR=build install
+
+FROM debian:10
+COPY --from=0 /root/wine/build/ /
+COPY --from=0 /usr/lib/gcc/x86_64-w64-mingw32/8.3-win32 /usr/lib/gcc/x86_64-w64-mingw32/8.3-win32
+COPY --from=0 /usr/lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu
+COPY --from=0 /lib /lib
+WORKDIR /root

--- a/README-Validity
+++ b/README-Validity
@@ -1,29 +1,8 @@
-Configured with:
+Hacked version of Wine for https://github.com/uunicorn/synaWudfBioUsb-sandbox
 
-./configure \
-    --with-gnutls  \
-    --without-hal \
-    --disable-tests  \
-    --enable-maintainer-mode \
-    --libdir=/usr/lib/x86_64-linux-gnu/wine \
-    --bindir=/usr/lib/wine  \
-    --mandir=/usr/share/man  \
-    --includedir=/usr/include/wine \
-    --datarootdir=/usr/share/wine  \
-    CFLAGS='-g -O2 -fdebug-prefix-map=<your_source_tree_location>=. -fstack-protector-strong -Wformat -Werror=format-security -Wno-error' \
-    CPPFLAGS='-Wdate-time -D_FORTIFY_SOURCE=2'  \
-    CXXFLAGS='-g -O2 -fdebug-prefix-map=<your_source_tree_location>=. -fstack-protector-strong -Wformat -Werror=format-security' \
-    FCFLAGS='-g -O2 -fdebug-prefix-map=<your_source_tree_location>=. -fstack-protector-strong'  \
-    FFLAGS='-g -O2 -fdebug-prefix-map=<your_source_tree_location>=. -fstack-protector-strong'  \
-    GCJFLAGS='-g -O2 -fdebug-prefix-map=<your_source_tree_location>=. -fstack-protector-strong'  \
-    LDFLAGS='-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now -Wl,-rpath,/usr/lib/x86_64-linux-gnu/wine'  \
-    OBJCFLAGS='-g -O2 -fdebug-prefix-map=<your_source_tree_location>=. -fstack-protector-strong -Wformat -Werror=format-security'  \
-    OBJCXXFLAGS='-g -O2 -fdebug-prefix-map=<your_source_tree_location>=. -fstack-protector-strong -Wformat -Werror=format-security'  \
-    --without-oss  \
-    --enable-win64
+To build the container:
+```sh
+docker build -t wine:validity .
+```
 
-
-Replace <your_source_tree_location> whith a place where you checked out the sources.
-
-USB VID:PID is hardcoded in dlls/winusb/winusb.c. 
-Change it to whatever you have. By default it is 138a:0097.
+Be patient, it will take about 12 minutes to build on a 4-core i7 machine.


### PR DESCRIPTION
Building Wine in Docker is easier and prevents polluting the base system with tons of build dependencies.